### PR TITLE
Make OS aware BiocParallel setting

### DIFF
--- a/R/module.R
+++ b/R/module.R
@@ -101,8 +101,11 @@ featuresCounts <- function(features,
 
   ## Setup parallel number
   register(SerialParam())
-  suppressWarnings( register(MulticoreParam(workers = parallel)) )
-  register(SnowParam(workers = parallel))
+  if (.Platform$OS.type == "windows") {
+      register(SnowParam(workers = parallel))  # Windows alternative
+  } else {
+      suppressWarnings( register(MulticoreParam(workers = parallel)) )  # Unix/macOS
+  }
 
   ## Setup bam file list
   bam_lst = BamFileList(file = bam_dirs,


### PR DESCRIPTION
I had the following error running featuresCounts() under linux OS. I fixed it by checking `.Platform$OS.type == "windows"`.

`Count reads on bin features ... 
Stop worker failed with the error: wrong args for environment subassignment
Error: BiocParallel errors
  3 remote errors, element index: 1, 6, 11
  27 unevaluated and other errors
  first remote error:
Error in elementNROWS(reads): could not find function "elementNROWS"`
